### PR TITLE
Small fixes

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,11 @@
+{
+	"files.exclude": {
+		"bird-core": true,
+		"bird-ide": true,
+		"bird-example": true,
+		"bird-ide": true,
+		"bird-nescio-ide": true,
+		"bird-nescio-tests": true,
+		"nest": true
+	}
+}

--- a/bird-core/src/main/rascal/lang/bird/Generator2Nest.rsc
+++ b/bird-core/src/main/rascal/lang/bird/Generator2Nest.rsc
@@ -333,7 +333,7 @@ str generateSideCondition((SideCondition) `? (<Expr e>)`, str parentId, DId this
 // 		If not, enforce constraint in type checker (together with type of it)
 str compileDeclInStruct(current:(DeclInStruct) `<Type ty>[]  <DId id> <Arguments? args> <Size? size> while (<Expr e>)`, str parentId, list[str] formalIds, str basePkg, rel[loc,loc] useDefs, map[loc, AType] types) =		 
 	"<generateNestType(current.ty, basePkg, types)> $<makeId(id)> = TokenList.parseWhile(__$src, __$ctx,
-    '	(s, c) -\> <generateParsingInstruction(ty, [e | aargs <- args, e <- aargs.args], [], basePkg, useDefs, types, src = "s", ctx = "c")>,
+    '	(s, c) -\> <generateParsingInstruction(ty, [e | aargs <- args, Expr e <- aargs.args], [], basePkg, useDefs, types, src = "s", ctx = "c")>,
     '	it -\> (<compile(e, id, basePkg, useDefs, types)>)
     ');";
     

--- a/bird.code-workspace
+++ b/bird.code-workspace
@@ -1,10 +1,6 @@
 {
 	"folders": [
 		{
-			"name": "bird",
-			"path": "."
-		},
-		{
 			"name": "bird-core",
 			"path": "bird-core"
 		},
@@ -17,6 +13,10 @@
 		},
 		{
 			"path": "nest"
+		},
+		{
+			"name": "bird",
+			"path": "."
 		}
 	],
 	"settings": {


### PR DESCRIPTION
* Fixed an issue where a bound variable was used in a pattern, where a fresh variable was intended
* Changed the workspace file to make VS Code's Java extension work, and avoid double entries in the VS Code explorer